### PR TITLE
POC for copying current URL to OS clipboard to share

### DIFF
--- a/src/ui/core/footer/Footer.component.js
+++ b/src/ui/core/footer/Footer.component.js
@@ -13,6 +13,26 @@ const FooterComponent = React.createClass({
     selectedStream: PropTypes.object
   },
 
+  copyUrlToClipboard() {
+    let tempUrlTextArea = document.createElement('textarea')
+    tempUrlTextArea.value = window.location.href
+
+    document.body.appendChild(tempUrlTextArea);
+    tempUrlTextArea.select();
+
+    let copyButton = document.getElementById('copyToClipboard')
+
+    try {
+      let success = document.execCommand('copy');
+      copyButton.innerHTML = 'Copied!'
+    } catch (error) {
+      copyButton.innerHTML = '&Oslash;'
+    }
+
+    document.body.removeChild(tempUrlTextArea);
+
+  },
+
   render () {
     let { view, selectedStream } = this.props
     let listText = isEmpty(selectedStream) ? 'List' : 'Details'
@@ -20,7 +40,7 @@ const FooterComponent = React.createClass({
       <div className={classes.menu}>
         <button onClick={this.props.setViewToList} className={view === LIST ? classes.selected : classes.item}>{listText}</button>
         <button onClick={this.props.setViewToMap} className={view === MAP ? classes.selected : classes.item}>Map</button>
-        <Link to={'/'} className={classes.help}>Help</Link>
+        <button onClick={this.copyUrlToClipboard} id="copyToClipboard" className={classes.copy}>Copy</button>
       </div>
     </div>)
   }

--- a/src/ui/core/footer/Footer.scss
+++ b/src/ui/core/footer/Footer.scss
@@ -36,7 +36,7 @@
   cursor: pointer;
 }
 
-.help {
+.copy {
   composes: item;
   padding-top: 7px !important;
 }


### PR DESCRIPTION
For some reason straight copying the `location.href` on certain browsers seemed a little dicey, so a temporary textarea is created containing the current url, and then removed.

*This is not currently tied into the application state - this will be addressed (if needed) at a later date

**Addressing Issue #1 