### PR TITLE
Data-driven (YUSSS!) styles

### DIFF
--- a/src/ui/@state/@region/map/MapboxGlMap/styles/RestrictionSection.style.js
+++ b/src/ui/@state/@region/map/MapboxGlMap/styles/RestrictionSection.style.js
@@ -41,16 +41,13 @@ export const RestrictionSectionActiveStyle = {
       ]
     }, // colors.RestrictionYellow
     'line-color': {
-      property: 'restriction_id',
+      property: 'color',
       type: 'categorical',
       stops: [
-        [0, colors.RestrictionYellow],
-        [7, '#FF4E10'],
-        [8, colors.RestrictionYellow],
-        [17, colors.RestrictionYellow],
-        [18, colors.StreamBlue],
-        [19, colors.RestrictionYellow],
-        [100, colors.RestrictionYellow]
+        ['red', colors.Red],
+        ['yellow', colors.RestrictionYellow],
+        ['white', colors.White],
+        ['blue', colors.StreamBlue]
       ]
 
     },


### PR DESCRIPTION
<img width="593" alt="screen shot 2017-05-17 at 11 59 39 am" src="https://cloud.githubusercontent.com/assets/1424223/25315550/594d7de0-281c-11e7-8330-e347eb4e78dc.png">

Map now correctly handles stream colors.