### PR TITLE
Brighten contrast

### DIFF
--- a/src/ui/@state/@region/@stream/details/Details.scss
+++ b/src/ui/@state/@region/@stream/details/Details.scss
@@ -77,7 +77,7 @@
   margin-bottom: 10px;
   display: inline-flex;
   width: 100%;
-  color: $off-white;
+  color: $white;
 }
 
 .listItem {

--- a/src/ui/@state/@region/list/streamItem/StreamItem.scss
+++ b/src/ui/@state/@region/list/streamItem/StreamItem.scss
@@ -11,7 +11,7 @@
   width: 100%;
   color: inherit;
   text-decoration: inherit;
-
+  color: $white;
   .media {
     order: 1;
   }
@@ -38,7 +38,7 @@
 
 .open {
   composes: zeldaText;
-  color: $off-white;
+  color: $white;
 }
 
 // .openEmphasis {
@@ -70,6 +70,7 @@
   composes: numberCircle;
   color: $green;
   font-size: 0.8em;
+  font-weight: 500;
 }
 
 .publicBridgesBadgeDull {

--- a/src/ui/core/header/Header.scss
+++ b/src/ui/core/header/Header.scss
@@ -122,7 +122,7 @@ $cautionaryYellow: transparentize($yellow, 0.8);
   padding-left: 10px;
 
   .top {
-    color: $off-white;
+    color: $white;
   }
 
   .bottom {

--- a/src/ui/core/header/search/Search.scss
+++ b/src/ui/core/header/search/Search.scss
@@ -21,6 +21,6 @@ $padding: 7px;
   }
 
   input[type="search"]::placeholder {
-    color: #555;
+    color: $off-white;
   }
 }

--- a/src/ui/core/regulations/RegulationsSummary.scss
+++ b/src/ui/core/regulations/RegulationsSummary.scss
@@ -15,7 +15,7 @@
 
 .open {
   composes: zeldaText;
-  color: $off-white;
+  color: $white;
 }
 
 .openEmphasis {

--- a/src/ui/styles/NumberCircle.scss
+++ b/src/ui/styles/NumberCircle.scss
@@ -9,7 +9,7 @@ $circle-size: 1.35em;
   box-sizing: initial;
 
   // background: #fff;
-  border: 0.08em solid;
+  border: 0.13em solid;
 
   // color: #666;
   text-align: center;

--- a/src/ui/styles/core.scss
+++ b/src/ui/styles/core.scss
@@ -18,7 +18,7 @@
     margin: 0;
     padding: 0;
     height: 100%;
-
+    color: $white;
     // background-color: $green;
 
     @include book-font;


### PR DESCRIPTION
![screen shot 2017-08-23 at 7 19 42 pm](https://user-images.githubusercontent.com/1424223/29643950-16eeb438-8838-11e7-9de3-be8e84246762.png)

Search placeholder text is brighter.
Most text, across the board, is switched to `#fff` white for legibility reasons. This will help anglers with sunglasses read their phones in bright mid-day sunlight.