### PR TITLE
#117 labels selectors in d3 match correctly on enter/exit

### DIFF
--- a/src/ui/page/header/minimap/svgMinimap/SvgMinimap.component.tsx
+++ b/src/ui/page/header/minimap/svgMinimap/SvgMinimap.component.tsx
@@ -475,7 +475,6 @@ export class SvgMinimapComponent extends React.Component<IMinimapSvgProps> {
     regionsGeoJson: RegionFeatureCollection
   ) {
     const { isExpanded } = this.props
-    console.log('drawing displayed regions')
     const regionsWithLabels = isExpanded ? regionsGeoJson.features : []
     const regionSelection = this.regionLabelsGroup
       .selectAll(`text.js-d3-regions-labels`)
@@ -489,7 +488,6 @@ export class SvgMinimapComponent extends React.Component<IMinimapSvgProps> {
     })
     regionSelection
       .enter()
-      .append('g')
       .append('text')
       .attr('data-name', item => item.properties.long_name)
       .text(item => {


### PR DESCRIPTION
![2018-07-14_12-41-54](https://user-images.githubusercontent.com/1424223/42726974-45767900-8763-11e8-9ed8-efb3542bbbfb.gif)

this kills the bug