### PR TITLE
de-reference variables correctly for dark theme minimap

### DIFF
--- a/src/ui/page/header/minimap/svgMinimap/SvgMinimap.scss
+++ b/src/ui/page/header/minimap/svgMinimap/SvgMinimap.scss
@@ -28,8 +28,8 @@
 
 :global(.ts-dark) {
   .container {
-    --backdrop-state-background: lighten($backgroundDark, 2);
-    --selected-region-background: lighten($backgroundDark, 10);
+    --backdrop-state-background: #{lighten($black, 0)};
+    --selected-region-background: #{lighten($backgroundDark, 10)};
   }
 }
 


### PR DESCRIPTION
Regions in dark mode are lighter than their parent US States.

![2018-09-22_11-14-50](https://user-images.githubusercontent.com/1424223/45919295-aafe6b80-be58-11e8-9754-4147226843b8.gif)
