### PR TITLE
Publicly is spelled correctly. Resolves #210

### DIFF
--- a/src/api/region/Region.accessPoints.ts
+++ b/src/api/region/Region.accessPoints.ts
@@ -13,9 +13,9 @@ export enum CrossingTypes {
 
 const MINIMUM_LENGTH_MILES = 0.07
 
-export const NONE_TEXT = 'No bridges over publically fishable land.'
-export const SINGLE_TEXT = ' bridge over publically fishable land.'
-export const MANY_TEXT = ' bridges over publically fishable land.'
+export const NONE_TEXT = 'No bridges over publicly fishable land.'
+export const SINGLE_TEXT = ' bridge over publicly fishable land.'
+export const MANY_TEXT = ' bridges over publicly fishable land.'
 
 const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
 const alphabetLength = alphabet.length

--- a/src/ui/core/micromap/canvas/_stubs/garvin-brook.json
+++ b/src/ui/core/micromap/canvas/_stubs/garvin-brook.json
@@ -84,7 +84,7 @@
       "permissionRequiredBridgeCount": 3,
       "unsafeBridgeCount": 10,
       "uninterestingBridgeCount": 0,
-      "bridgeText": " bridges over publically fishable land."
+      "bridgeText": " bridges over publicly fishable land."
     },
     "geometry": {
       "type": "LineString",
@@ -9344,7 +9344,7 @@
               "permissionRequiredBridgeCount": 2,
               "unsafeBridgeCount": 0,
               "uninterestingBridgeCount": 0,
-              "bridgeText": "No bridges over publically fishable land."
+              "bridgeText": "No bridges over publicly fishable land."
             },
             "geometry": {
               "type": "LineString",
@@ -12560,7 +12560,7 @@
                       "permissionRequiredBridgeCount": 0,
                       "unsafeBridgeCount": 0,
                       "uninterestingBridgeCount": 0,
-                      "bridgeText": "No bridges over publically fishable land."
+                      "bridgeText": "No bridges over publicly fishable land."
                     },
                     "geometry": {
                       "type": "LineString",
@@ -12980,7 +12980,7 @@
               "permissionRequiredBridgeCount": 0,
               "unsafeBridgeCount": 2,
               "uninterestingBridgeCount": 0,
-              "bridgeText": " bridge over publically fishable land."
+              "bridgeText": " bridge over publicly fishable land."
             },
             "geometry": {
               "type": "LineString",

--- a/src/ui/core/micromap/canvas/_stubs/trout-run-creek.json
+++ b/src/ui/core/micromap/canvas/_stubs/trout-run-creek.json
@@ -84,7 +84,7 @@
       "permissionRequiredBridgeCount": 2,
       "unsafeBridgeCount": 0,
       "uninterestingBridgeCount": 0,
-      "bridgeText": " bridges over publically fishable land."
+      "bridgeText": " bridges over publicly fishable land."
     },
     "geometry": {
       "type": "LineString",

--- a/src/ui/core/streamDetails/PublicBridges.component.tsx
+++ b/src/ui/core/streamDetails/PublicBridges.component.tsx
@@ -20,7 +20,7 @@ export const PublicBridgesComponent: React.SFC<IPublicBridgesComponent> = (props
     )
   return (
     <React.Fragment>
-      {countSymbol} {noun} over publically fishable land.
+      {countSymbol} {noun} over publicly fishable land.
     </React.Fragment>
   )
 }


### PR DESCRIPTION
Amended spelling on 4 files.